### PR TITLE
add AverageBlur, GaussianBlur, Sharpen transform methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ mask = mean(masks)
 | FiveCrops      | crop_height<br>crop_width | int<br>int                        |
 | AdjustContrast | factors                   | List\[float]                      |
 | AdjustBrightness|factors                   | List\[float]                      |
+| AverageBlur    | kernel_sizes              | List[Union[Tuple[int, int], int]] |
+| GaussianBlur   | kernel_sizes<br>sigma     | List[Union[Tuple[int, int], int]]<br>Optional[Union[Tuple[float, float], float]]|
+| Sharpen        | kernel_sizes              | List[int]                         |
  
 ## Aliases (Combos)
 

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ mask = mean(masks)
 | FiveCrops      | crop_height<br>crop_width | int<br>int                        |
 | AdjustContrast | factors                   | List\[float]                      |
 | AdjustBrightness|factors                   | List\[float]                      |
-| AverageBlur    | kernel_sizes              | List[Union[Tuple[int, int], int]] |
-| GaussianBlur   | kernel_sizes<br>sigma     | List[Union[Tuple[int, int], int]]<br>Optional[Union[Tuple[float, float], float]]|
+| AverageBlur    | kernel_sizes              | List\[Union\[Tuple\[int, int], int]] |
+| GaussianBlur   | kernel_sizes<br>sigma     | List\[Union\[Tuple\[int, int], int]]<br>Optional\[Union\[Tuple\[float, float], float]]|
 | Sharpen        | kernel_sizes              | List[int]                         |
  
 ## Aliases (Combos)

--- a/patta/__init__.py
+++ b/patta/__init__.py
@@ -18,6 +18,9 @@ from .transforms import (
     Resize,
     AdjustContrast,
     AdjustBrightness,
+    AverageBlur,
+    GaussianBlur,
+    Sharpen,
 )
 
 from . import aliases

--- a/patta/functional.py
+++ b/patta/functional.py
@@ -204,6 +204,7 @@ def sharpen(x, kernel_size: int = 3):
         return x
     assert kernel_size > 0 and kernel_size % 2 == 1, "kernel_size both must be positive and odd"
     kernel = get_laplacian_kernel(kernel_size).astype(np.float32)
+    kernel = kernel.astype(np.float32)
     kernel = paddle.to_tensor(kernel)
     x_laplacian = filter2d(x, kernel)
     x = x - x_laplacian

--- a/patta/functional.py
+++ b/patta/functional.py
@@ -1,7 +1,9 @@
+from typing import Optional, Tuple, Union
+
+import cv2
+import numpy as np
 import paddle
 import paddle.nn.functional as F
-import numpy as np
-import cv2
 
 
 def rot90(x, k=1):
@@ -64,9 +66,7 @@ def scale(x, scale_factor, interpolation="nearest", align_corners=False):
     h, w = x.shape[2:]
     new_h = int(h * scale_factor)
     new_w = int(w * scale_factor)
-    return F.interpolate(
-        x, size=(new_h, new_w), mode=interpolation, align_corners=align_corners
-    )
+    return F.interpolate(x, size=(new_h, new_w), mode=interpolation, align_corners=align_corners)
 
 
 def resize(x, size, interpolation="nearest", align_corners=False):
@@ -145,6 +145,78 @@ def adjust_brightness(x, brightness_factor: float=1.):
     x = cv2.LUT(x, table)
     x = x.astype(np.float32)
     return paddle.to_tensor(x)
+
+def filter2d(x, kernel):
+    """applies an arbitrary linear filter to an image"""
+    C = x.shape[1]
+    kernel = kernel.reshape((1, 1, *kernel.shape))
+    kernel = paddle.concat([kernel for _ in range(C)], axis=0)
+    return F.conv2d(x, kernel, stride=1, padding="same", groups=C)
+
+
+def average_blur(x, kernel_size: Union[Tuple[int, int], int] = 3):
+    """smooths the input image"""
+    cv2.blur
+    if isinstance(kernel_size, int):
+        kernel_size = (kernel_size, kernel_size)
+    if kernel_size == (1, 1):
+        return x
+    assert (
+        kernel_size[0] > 0 and kernel_size[1] > 0 and kernel_size[0] % 2 == 1 and kernel_size[1] % 2 == 1
+    ), "kernel_size both must be positive and odd"
+    kernel = np.ones(kernel_size[0] * kernel_size[1], dtype=np.float32)
+    kernel = kernel / (kernel_size[0] * kernel_size[1])
+    kernel = kernel.reshape((kernel_size[1], kernel_size[0]))
+    assert kernel.shape == (kernel_size[1], kernel_size[0])
+    kernel = paddle.to_tensor(kernel)
+    return filter2d(x, kernel)
+
+
+def gaussian_blur(
+    x,
+    kernel_size: Union[Tuple[int, int], int] = 3,
+    sigma: Optional[Union[Tuple[float, float], float]] = None
+):
+    """smooths the input image with the specified Gaussian kernel"""
+    cv2.GaussianBlur
+    if isinstance(kernel_size, int):
+        kernel_size = (kernel_size, kernel_size)
+    if kernel_size == (1, 1):
+        return x
+    if sigma is None:
+        sigma = (kernel_size[0] - 1) / 4.0
+    if isinstance(sigma, (int, float)):
+        sigma = (sigma, sigma)
+    assert kernel_size[0] > 0 and kernel_size[1] > 0 and kernel_size[0] % 2 == 1 and \
+           kernel_size[1] % 2 == 1, "kernel_size both must be positive and odd"
+    kernel_x = cv2.getGaussianKernel(kernel_size[0], sigma[0])
+    kernel_y = cv2.getGaussianKernel(kernel_size[1], sigma[1])
+    kernel = kernel_y @ kernel_x.transpose()
+    kernel = kernel.astype(np.float32)
+    assert kernel.shape == (kernel_size[1], kernel_size[0])
+    kernel = paddle.to_tensor(kernel)
+    return filter2d(x, kernel)
+
+
+def sharpen(x, kernel_size: int = 3):
+    """sharpen the input image"""
+    if kernel_size == 1:
+        return x
+    assert kernel_size > 0 and kernel_size % 2 == 1, "kernel_size both must be positive and odd"
+    kernel = get_laplacian_kernel(kernel_size).astype(np.float32)
+    kernel = paddle.to_tensor(kernel)
+    x_laplacian = filter2d(x, kernel)
+    x = x - x_laplacian
+    x = x.clip(0, 255)
+    return x
+
+
+def get_laplacian_kernel(kernel_size):
+    assert kernel_size > 0 and kernel_size % 2 == 1, "kernel_size both must be positive and odd"
+    kernel = np.ones((kernel_size, kernel_size))
+    mid = kernel_size // 2
+    kernel[mid, mid] = 1 - kernel_size ** 2
+    return kernel
 
 
 def _disassemble_keypoints(keypoints):

--- a/patta/transforms.py
+++ b/patta/transforms.py
@@ -354,3 +354,71 @@ class AdjustBrightness(ImageOnlyTransform):
             return F.adjust_brightness(image, factor)
         return image
 
+
+class AverageBlur(ImageOnlyTransform):
+    """Apply average blur to the input image
+
+    Args:
+        kernel_sizes (List[Union[Tuple[int, int], int]]): kernel size of average blur
+    """
+
+    identity_param = 1
+
+    def __init__(
+        self,
+        kernel_sizes: List[Union[Tuple[int, int], int]],
+    ):
+        if self.identity_param not in kernel_sizes:
+            kernel_sizes = [self.identity_param] + list(kernel_sizes)
+        super().__init__("kernel_size", kernel_sizes)
+
+    def apply_aug_image(self, image, kernel_size, **kwargs):
+        if kernel_size == self.identity_param:
+            return image
+        return F.average_blur(image, kernel_size)
+
+
+class GaussianBlur(ImageOnlyTransform):
+    """Apply gaussian blur to the input image
+
+    Args:
+        kernel_sizes (List[Union[Tuple[int, int], int]]): kernel size of gaussian blur
+        sigma (Optional[Union[Tuple[float, float], float]]): gaussian kernel standard deviation
+    """
+    
+    identity_param = 1
+
+    def __init__(
+        self,
+        kernel_sizes: List[Union[Tuple[int, int], int]],
+        sigma: Optional[Union[Tuple[float, float], float]] = None
+    ):
+        if self.identity_param not in kernel_sizes:
+            kernel_sizes = [self.identity_param] + list(kernel_sizes)
+        self.sigma = sigma
+        super().__init__("kernel_size", kernel_sizes)
+
+    def apply_aug_image(self, image, kernel_size, **kwargs):
+        if kernel_size == self.identity_param:
+            return image
+        return F.gaussian_blur(image, kernel_size, self.sigma)
+
+
+class Sharpen(ImageOnlyTransform):
+    """Apply sharpen to the input image
+
+    Args:
+        kernel_sizes (List[int]): kernel size of sharpen
+    """
+
+    identity_param = 1
+
+    def __init__(self, kernel_sizes: List[int]):
+        if self.identity_param not in kernel_sizes:
+            kernel_sizes = [self.identity_param] + list(kernel_sizes)
+        super().__init__("kernel_size", kernel_sizes)
+
+    def apply_aug_image(self, image, kernel_size, **kwargs):
+        if kernel_size == self.identity_param:
+            return image
+        return F.sharpen(image, kernel_size)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -40,6 +40,9 @@ def test_aug_deaug_mask(transform):
         tta.Resize(sizes=[(4, 5), (8, 10), (2, 2)], interpolation="nearest"),
         tta.AdjustBrightness(factors=[0.5, 1.0, 1.5]),
         tta.AdjustContrast(factors=[0.5, 1.0, 1.5]),
+        tta.AverageBlur(kernel_sizes=[(3, 3), (5, 3)]),
+        tta.GaussianBlur(kernel_sizes=[(3, 3), (5, 3)], sigma=0.3),
+        tta.Sharpen(kernel_sizes=[3]),
     ],
 )
 def test_label_is_same(transform):


### PR DESCRIPTION
添加以下增强方式

- AverageBlur
- GaussianBlur
- Sharpen

三种方式均利用 paddle.nn.functional.conv2d 实现，避免在 python 里使用低效的 for 循环

不过该种方式与 opencv 中的边缘处理并不相同，并未做特殊化处理，直接 pad 0 后进行卷积，不过一般情况下边缘的影响应当并不会很大，因此并未做相关处理。

AI Studio 自测文件（部分可见，有效期三天）：<https://aistudio.baidu.com/studio/project/partial/verify/2586123/12a1036855424330a5f71e6989f35e67>